### PR TITLE
Fix some memory leaks in ApvlvPDF::pagesearch

### DIFF
--- a/src/ApvlvPdf.cc
+++ b/src/ApvlvPdf.cc
@@ -329,6 +329,7 @@ namespace apvlv
     GList *list = poppler_page_find_text (page, str);
     if (list == NULL)
       {
+	g_object_unref(page);
 	return NULL;
       }
 
@@ -345,7 +346,12 @@ namespace apvlv
 	//             rect->y2);
 	ApvlvPos pos = { rect->x1, rect->x2, rect->y1, rect->y2 };
 	poses->push_back (pos);
+
+	poppler_rectangle_free(rect);
       }
+
+    g_list_free(list);
+    g_object_unref(page);
 
     return poses;
   }


### PR DESCRIPTION
apvlv was leaking memory in the pagesearch function. Since I tend to
search 1500+ page documents regularly I would pretty quickly run out of
memory and my system would start thrashing.

This patch adds the appropriate unref & free calls to avoid this
particular memory leak.

Testcase:
1. Configure apvlv with cmake -D CMAKE_BUILD_TYPE=DEBUG
2. Optionally start htop in another window to observe the memory blowout
3. valgrind --error-limit=no --leak-check=full apvlv very_large_document.pdf
4. Search for a string that does not exist in the document
5. Close apvlv and read valgrind summary

Before (Note almost 1/2 GB memory is listed as possibly lost)
==14302== LEAK SUMMARY:
==14302==    definitely lost: 4,430 bytes in 9 blocks
==14302==    indirectly lost: 11,392 bytes in 354 blocks
==14302==      possibly lost: 562,418,510 bytes in 3,798,367 blocks
==14302==    still reachable: 1,704,596 bytes in 13,324 blocks

After (down to 16M possibly lost):
==22458== LEAK SUMMARY:
==22458==    definitely lost: 4,416 bytes in 8 blocks
==22458==    indirectly lost: 11,392 bytes in 354 blocks
==22458==      possibly lost: 16,820,645 bytes in 149,355 blocks
==22458==    still reachable: 3,892,602 bytes in 9,368 blocks

Signed-off-by: Ian Munsie darkstarsword@gmail.com
