### PR TITLE
Fix a few more memory leaks in ApvlvPDF

### DIFF
--- a/src/ApvlvPdf.cc
+++ b/src/ApvlvPdf.cc
@@ -306,6 +306,7 @@ namespace apvlv
 	  {
 	    poppler_page_get_size (page, x, y);
 	  }
+	g_object_unref(page);
 	return true;
       }
     return false;
@@ -371,6 +372,7 @@ namespace apvlv
     PopplerRectangle rect = { x1, y1, x2, y2 };
     *out = poppler_page_get_text (page, POPPLER_SELECTION_WORD, &rect);
 #endif
+    g_object_unref(page);
     if (*out != NULL)
       {
 	return true;
@@ -390,6 +392,7 @@ namespace apvlv
       }
 
     poppler_page_render_to_pixbuf (tpage, 0, 0, ix, iy, zm, rot, pix);
+    g_object_unref(tpage);
     return true;
   }
 
@@ -450,6 +453,7 @@ namespace apvlv
     GList *list = poppler_page_get_link_mapping (page);
     if (list == NULL)
       {
+	g_object_unref(page);
 	return NULL;
       }
 
@@ -484,6 +488,8 @@ namespace apvlv
 	  }
       }
 
+    g_list_free(list);
+    g_object_unref(page);
     return links;
   }
 
@@ -584,6 +590,7 @@ namespace apvlv
     if (page != NULL)
       {
 	poppler_page_render_for_printing (page, cr);
+	g_object_unref(page);
 	return true;
       }
     else


### PR DESCRIPTION
I was still seeing apvlv leak memory while scrolling through pdf
documents, which valgrind pointed to apvlv::ApvlvPDF::render as the
main culprit.

I've gone through the ApvlvPdf class and added a g_object_unref for
every occurance of poppler_document_get_page, as well as freeing another
list in ApvlvPDF::getlinks.

Testcase:
1. Configure apvlv with cmake -D CMAKE_BUILD_TYPE=DEBUG
2. Optionally start htop in another window to observe the memory blowout
3. valgrind --error-limit=no --leak-check=full apvlv very_large_document.pdf
4. Continually press page down to scroll through the document
5. Close apvlv and read valgrind summary

Before (note over 100M are marked as possibly lost):
==18333== LEAK SUMMARY:
==18333==    definitely lost: 4,416 bytes in 8 blocks
==18333==    indirectly lost: 11,392 bytes in 354 blocks
==18333==      possibly lost: 135,511,892 bytes in 1,029,946 blocks
==18333==    still reachable: 8,670,227 bytes in 37,143 blocks

After (Down to under 10MB marked as possibly lost):
==22504== LEAK SUMMARY:
==22504==    definitely lost: 4,416 bytes in 8 blocks
==22504==    indirectly lost: 11,392 bytes in 354 blocks
==22504==      possibly lost: 9,305,771 bytes in 25,887 blocks
==22504==    still reachable: 3,286,064 bytes in 11,783 blocks

Signed-off-by: Ian Munsie darkstarsword@gmail.com
