### PR TITLE
Use the current page when zooming to page width/height

### DIFF
--- a/src/ApvlvDoc.cc
+++ b/src/ApvlvDoc.cc
@@ -727,7 +727,8 @@ namespace apvlv
 
     if (mFile != NULL)
       {
-	mFile->pagesize (0, mRotatevalue, &mPagex, &mPagey);
+	gint pn = max(0, pagenumber() - 1);
+	mFile->pagesize (pn, mRotatevalue, &mPagex, &mPagey);
 
 	if (mZoommode == FITWIDTH)
 	  {


### PR DESCRIPTION
Some PDF documents mix pages of different sizes, so use the current page
rather than page 0 when zooming to page width or height.
