### PR TITLE
gg,G,gt and gT count related behaviour changed to be consistent with vim

### DIFF
--- a/Startup.tex
+++ b/Startup.tex
@@ -144,15 +144,19 @@ reload the current file.
 
 [count] rotate the document page 
 
+\item gg
+
+  go to beggining of document, or (preceded by [count]) show page [count]
+
 \item G
 
   go to end of document, or (preceded by [count]) show page [count]
 
 \item gt
 
-show next tab
+show next tab, or (preceded by [count]) show tab [count]
 
-\item gT
+\item gT, or (preceded by [count]) show tab [count]
 
 show previous tab
 

--- a/src/ApvlvDoc.cc
+++ b/src/ApvlvDoc.cc
@@ -631,7 +631,7 @@ namespace apvlv
 	if (!has) {
 		showpage (mFile->pagesum () - 1);
 	} else {
-		showpage (ct);
+		showpage (ct - 1);
 	}
 	break;
       case 'm':

--- a/src/ApvlvView.cc
+++ b/src/ApvlvView.cc
@@ -59,6 +59,7 @@ namespace apvlv
   ApvlvView::ApvlvView (const char *filename):mCurrTabPos (-1)
   {
     mProCmd = 0;
+    mProCmdCnt = 0;
 
     mCurrHistroy = -1;
 
@@ -833,6 +834,7 @@ namespace apvlv
   {
     guint procmd = mProCmd;
     mProCmd = 0;
+    mProCmdCnt = 0;
     switch (procmd)
       {
       case CTRL ('w'):
@@ -856,15 +858,21 @@ namespace apvlv
 	break;
 
       case 'g':
-	if (ct == 0)
-	  ct = 1;
-
-	if (key == 't')
-	  switchtab (mCurrTabPos + ct);
-	else if (key == 'T')
-	  switchtab (mCurrTabPos - ct);
-	else if (key == 'g')
-	  crtadoc ()->showpage (0);
+	if (key == 't'){
+	  if (ct == 0)
+	    switchtab (mCurrTabPos+1);
+	  else
+	    switchtab (ct-1);
+        }else if (key == 'T'){
+	  if (ct == 0)
+	    switchtab (mCurrTabPos-1);
+	  else
+	    switchtab (ct-1);
+        }else if (key == 'g'){
+	  if (ct == 0)
+	    ct = 1;
+	  crtadoc ()->showpage (ct-1);
+        }
 	break;
 
       default:
@@ -879,13 +887,14 @@ namespace apvlv
   {
     if (mProCmd != 0)
       {
-	return subprocess (ct, key);
+	return subprocess (mProCmdCnt, key);
       }
 
     switch (key)
       {
       case CTRL ('w'):
 	mProCmd = CTRL ('w');
+        mProCmdCnt = has ? ct : 0;
 	return NEED_MORE;
 	break;
       case 'q':
@@ -896,6 +905,7 @@ namespace apvlv
 	break;
       case 'g':
 	mProCmd = 'g';
+        mProCmdCnt = has ? ct : 0;
 	return NEED_MORE;
       default:
 	return crtadoc ()->process (has, ct, key);

--- a/src/ApvlvView.h
+++ b/src/ApvlvView.h
@@ -148,6 +148,7 @@ namespace apvlv
     int mCmdType;
 
     guint mProCmd;
+    int   mProCmdCnt;
 
     GtkWidget *mMainWindow;
 


### PR DESCRIPTION
This pull requests changes **gg**, **G**, **gt** and **gT** behaviour to be more consistent with how **vim** behaves
Now if the **gg** or **G** commands are prefixed with _count_ they jump to the page _count_
and if **gt** or **gT** commands are prefixed with _count_ they jump to the tab _count_
This behaviour is identical as in **vim**
**NOTE:** I've updated .tex documentation to however I don't have tools and nor do I have knowledge (as I'm not familiar with tools related to .tex) to generate .pdf file from source .tex file so if you are going to merge this pull request please refresh the .pdf file

Please review and merge it