### PR TITLE
gtk 3.22 related compile fixes

### DIFF
--- a/src/ApvlvDoc.cc
+++ b/src/ApvlvDoc.cc
@@ -1753,7 +1753,7 @@ namespace apvlv
 	g_signal_connect (item, "activate",
                           G_CALLBACK (apvlv_doc_copytoclipboard_cb), doc);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
+#if GTK_CHECK_VERSION(3, 22, 0)
 	gtk_menu_popup_at_pointer (GTK_MENU (menu), NULL);
 #else
         gtk_menu_popup (GTK_MENU (menu), NULL, NULL, NULL, NULL, 0, 0);

--- a/src/ApvlvView.cc
+++ b/src/ApvlvView.cc
@@ -71,7 +71,7 @@ namespace apvlv
 
     if (gParams->valueb ("fullscreen"))
       {
-#if GTK_CHECK_VERSION(3, 0, 0)
+#if GTK_CHECK_VERSION(3, 22, 0)
         GdkRectangle rect[1];
         GdkDisplay *display = gdk_display_get_default ();
         GdkMonitor *monitor = gdk_display_get_primary_monitor (display);


### PR DESCRIPTION
This functions were introduced only in gtk 3.22 so they fail to compile on 3.18