### PR TITLE
add check to see if pagesize() succeeds

### DIFF
--- a/src/ApvlvDoc.cc
+++ b/src/ApvlvDoc.cc
@@ -2200,7 +2200,11 @@ ApvlvDocCache::load (ApvlvDocCache *ac)
     }
 
   double tpagex, tpagey;
-  ac->mFile->pagesize (ac->mPagenum, gint (ac->mRotate), &tpagex, &tpagey);
+  if (!ac->mFile->pagesize (ac->mPagenum, gint (ac->mRotate), &tpagex, &tpagey))
+    {
+        errp("error getting pagesize for pagenum: %d", ac->mPagenum);
+        return;
+    };
 
   ac->mWidth = MAX ((tpagex * ac->mZoom + 0.5), 1);
   ac->mHeight = MAX ((tpagey * ac->mZoom + 0.5), 1);


### PR DESCRIPTION
`ApvlvPDF::pagesize()` returns `false` in case of an error. In this case, the `tpagex` and `tpagey` variables (in `ApvlvDocCache::Load()`) may be uninitialized, which can lead to an overflow later on. This patch adds a check for the return value of `Apvlv::pagesize()` and returns early in case of an error.