### PR TITLE
Fix apvlv.desktop mime types

### DIFF
--- a/apvlv.desktop
+++ b/apvlv.desktop
@@ -14,6 +14,6 @@ Comment[pl]=Minimalistyczna przeglądarka dokumentów
 Exec=apvlv %f
 Terminal=false
 Categories=Office;Viewer;
-MimeType=application/pdf;application/postscript;application/eps;application/x-eps;image/eps;image/x-eps;image/vnd.djvu;
+MimeType=application/pdf;application/epub+zip;image/vnd.djvu;
 Keywords=vim;pdf;
 Icon=x-office-document


### PR DESCRIPTION
.desktop claims non-existent support for postscript (and eps), and does not mention epub.

(That's how I discovered bug fixed by #88 -- attempt to `xdg-open file.ps` invoked apvlv, and it died with sigsegv)